### PR TITLE
`~/.gitconfig` のサンプルもリポジトリに追加

### DIFF
--- a/config/git/main_config
+++ b/config/git/main_config
@@ -1,0 +1,6 @@
+[user]
+	name = 515hikaru
+	email = 12kojima.takahiro@gmail.com
+[Include]
+    path = ~/dotfiles/config/git/aliases
+# vim: ft=gitconfig


### PR DESCRIPTION
`~/.gitconfig` を各ローカルマシンごとに作っていたが、リポジトリにつっこめばシンボリックリンクで共通化できることにいま気づいたのでそうした。