### PR TITLE
ファイルを開いたときにカーソルが本文にあるようにする

### DIFF
--- a/config/vim/vimrc
+++ b/config/vim/vimrc
@@ -19,7 +19,7 @@ filetype plugin indent on
 " Toggle を <C-n> にバインド
 map <C-n> :NERDTreeToggle<CR>
 " Vim 起動時に自動でファイルビューアーを開く
-autocmd vimenter * NERDTree
+autocmd vimenter * NERDTree | wincmd p
 
 colorscheme molokai
 set t_Co=256


### PR DESCRIPTION
* See: https://stackoverflow.com/questions/24808932/vim-open-nerdtree-and-move-the-cursor-to-the-file-editing-area